### PR TITLE
Fix ecs usage

### DIFF
--- a/lib/aws_pocketknife/cli/ecs.rb
+++ b/lib/aws_pocketknife/cli/ecs.rb
@@ -115,8 +115,8 @@ module AwsPocketknife
                   "pending_tasks_count","running_tasks_count", "status",
                   "cpu (units)", "mem (MiB)"
                 ]
-        headers_2 = ["total",
-          "total pending", "total running",
+        headers_2 = ["active", "draining", 
+          "tasks pending", "tasks running",
           "cpu_reserved / cpu_total", "mem_reserved / mem_total"
         ]
         data = []
@@ -124,7 +124,8 @@ module AwsPocketknife
         if instances.nil?
           puts "No instances found"
         else
-          count = 0
+          count_active = 0
+          count_draining = 0
           mem_cluster_total = 0.0
           mem_cluster_res_total = 0.0
           mem_percentage = 0.0
@@ -152,9 +153,10 @@ module AwsPocketknife
             cpu_cluster_total = cpu_cluster_total + cpu_total if info.status == "ACTIVE"
             cpu_cluster_res_total = cpu_cluster_res_total + cpu_available if info.status == "ACTIVE"
             cpu_percentage = (((cpu_cluster_total - cpu_cluster_res_total)/cpu_cluster_total) * 100).round(2)
-            count = count + 1
+            count_active = count_active + 1 if info.status == "ACTIVE"
+            count_draining = count_draining + 1 if info.status == "DRAINING"
           end
-            data_2 << [count,
+            data_2 << [count_active, count_draining, 
               pending_tasks_count_total, running_tasks_count_total,
               "#{(cpu_cluster_total - cpu_cluster_res_total).round(0)} / #{cpu_cluster_total.round(0)} (#{cpu_percentage} %)", "#{(mem_cluster_total - mem_cluster_res_total).round(0)} / #{mem_cluster_total.round(0)} (#{mem_percentage} %)"
             ]

--- a/lib/aws_pocketknife/cli/ecs.rb
+++ b/lib/aws_pocketknife/cli/ecs.rb
@@ -146,10 +146,10 @@ module AwsPocketknife
             ]
             pending_tasks_count_total = pending_tasks_count_total + info.pending_tasks_count
             running_tasks_count_total = running_tasks_count_total + info.running_tasks_count
-            mem_cluster_total = mem_cluster_total + mem_total
+            mem_cluster_total = mem_cluster_total + mem_total if info.status == "ACTIVE"
             mem_cluster_res_total = mem_cluster_res_total + mem_available if info.status == "ACTIVE"
             mem_percentage = (((mem_cluster_total - mem_cluster_res_total)/mem_cluster_total) * 100).round(2)
-            cpu_cluster_total = cpu_cluster_total + cpu_total
+            cpu_cluster_total = cpu_cluster_total + cpu_total if info.status == "ACTIVE"
             cpu_cluster_res_total = cpu_cluster_res_total + cpu_available if info.status == "ACTIVE"
             cpu_percentage = (((cpu_cluster_total - cpu_cluster_res_total)/cpu_cluster_total) * 100).round(2)
             count = count + 1

--- a/lib/aws_pocketknife/cli/main.rb
+++ b/lib/aws_pocketknife/cli/main.rb
@@ -4,6 +4,7 @@ require "aws_pocketknife"
 module AwsPocketknife
   module Cli
     class Main < Thor
+      map %w[--version -v] => :__print_version
 
       desc "ec2 SUBCOMMAND ...ARGS", "ec2 command lines"
       subcommand "ec2", AwsPocketknife::Cli::Ec2
@@ -32,6 +33,11 @@ module AwsPocketknife
       desc "ecs SUBCOMMAND ...ARGS", "ecs command lines"
       subcommand "ecs", AwsPocketknife::Cli::Ecs
 
+      desc "--version, -v", "print the version"
+      def __print_version
+        puts AwsPocketknife::VERSION
+      end
+    
     end
   end
 end

--- a/lib/aws_pocketknife/version.rb
+++ b/lib/aws_pocketknife/version.rb
@@ -1,3 +1,3 @@
 module AwsPocketknife
-  VERSION = "0.1.23"
+  VERSION = "0.1.24"
 end


### PR DESCRIPTION
ECS `cpu_reserved`, `cpu_total`, `mem_reserved` and `mem_total` were being wrongly reported. this fixes it